### PR TITLE
feat: Display labels for exercises

### DIFF
--- a/lib/screens/main/exercices_view.dart
+++ b/lib/screens/main/exercices_view.dart
@@ -59,17 +59,20 @@ class ExercicesView extends StatelessWidget {
                   onTap: () => onEditExercise(exercise),
                   child: Stack(
                     children: [
-                      Container(
-                        color: Theme.of(context).colorScheme.primaryContainer,
-                        child: Center(
-                          child: Padding(
-                            padding: const EdgeInsets.all(8.0),
-                            child: Text(
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Text(
                               exercise.name,
                               textAlign: TextAlign.center,
                               style: Theme.of(context).textTheme.titleMedium,
                             ),
-                          ),
+                            const SizedBox(height: 8),
+                            _buildExerciseTags(exercise, context, alignment: MainAxisAlignment.center),
+                          ],
                         ),
                       ),
                       Positioned(
@@ -115,6 +118,7 @@ class ExercicesView extends StatelessWidget {
               margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
               child: ListTile(
                 title: Text(exercise.name),
+                subtitle: _buildExerciseTags(exercise, context),
                 onTap: () => onEditExercise(exercise),
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
@@ -140,6 +144,48 @@ class ExercicesView extends StatelessWidget {
           },
         );
       },
+    );
+  }
+
+  Widget _buildExerciseTags(Exercise exercise, BuildContext context, {MainAxisAlignment alignment = MainAxisAlignment.start}) {
+    final List<Widget> tags = [];
+
+    if (exercise.type != null && exercise.type!.isNotEmpty) {
+      tags.add(Chip(
+        label: Text(exercise.type!),
+        backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+        labelStyle: TextStyle(color: Theme.of(context).colorScheme.onTertiaryContainer),
+        side: BorderSide.none,
+      ));
+    }
+
+    for (final tag in exercise.articulation) {
+      tags.add(Chip(
+        label: Text(tag),
+        backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+        labelStyle: TextStyle(color: Theme.of(context).colorScheme.onPrimaryContainer),
+        side: BorderSide.none,
+      ));
+    }
+
+    for (final tag in exercise.muscles) {
+      tags.add(Chip(
+        label: Text(tag),
+        backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+        labelStyle: TextStyle(color: Theme.of(context).colorScheme.onSecondaryContainer),
+        side: BorderSide.none,
+      ));
+    }
+
+    if (tags.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Wrap(
+      spacing: 4.0,
+      runSpacing: 4.0,
+      alignment: alignment,
+      children: tags,
     );
   }
 }


### PR DESCRIPTION
This commit implements the following changes:

- In the "Exercices" tab, labels for `articulation`, `muscles`, and `type` are now displayed for each exercise.
- The labels are shown as `Chip` widgets in both the list and grid views.
- A helper function `_buildExerciseTags` has been added to handle the creation of the labels and avoid code duplication.
- The chips are styled with different colors for each category to improve visual distinction.

This commit also includes previous work from this session:
- A `DEPLOY.md` file with local deployment instructions.
- Updates to `ETAT.md` and `GEMINI.md` to align documentation with the codebase.